### PR TITLE
Remove class from index name

### DIFF
--- a/src/main/groovy/com/ullink/testtools/elastic/TestExportTask.groovy
+++ b/src/main/groovy/com/ullink/testtools/elastic/TestExportTask.groovy
@@ -103,8 +103,8 @@ class TestExportTask extends Exec {
             def list = parseTestFiles(files)
             list.each {
                 def output = JsonOutput.toJson(it)
-                String index = indexPrefix + it.getClassname() + "-" + it.timestamp.find("([\\d-]+)")
-                index = index.toLowerCase().replace('.', '-')
+                String index = indexPrefix + it.timestamp.find("([\\d-]+)")
+                index = index.replace('.', '-')
                 String typeFinal
                 if (type instanceof String)
                     typeFinal = type

--- a/src/test/groovy/com/ullink/testtools/elastic/ElasticSearchProcessorTest.groovy
+++ b/src/test/groovy/com/ullink/testtools/elastic/ElasticSearchProcessorTest.groovy
@@ -27,7 +27,7 @@ class ElasticSearchProcessorTest {
             {"classname":"com.ullink.ultest.junit.integration.test.elastic.MathTest","failureType":null,"executionTime":1.0,"failureMessage":null,"timestamp":"2017-08-18T03:41:19","name":"subtract","resultType":"SUCCESS"}
          """
         try {
-            processor.add(new IndexRequest("testresults-com-ullink-ultest-junit-integration-test-elastic-mathtest-2017-08-19", "testcase", "subtract_2017-08-18T03:41:19").source(source, XContentType.JSON))
+            processor.add(new IndexRequest("testresults-2017-08-19", "testcase", "subtract_2017-08-18T03:41:19").source(source, XContentType.JSON))
             processor.close()
         }
         catch (Exception e) {


### PR DESCRIPTION
Having the class name in the index name generates a lot of indexes, which would likely lead to bad performances. See here for more information: https://www.elastic.co/guide/en/elasticsearch/guide/current/kagillion-shards.html

Now there is already a configurable prefix in order to avoid name conflicts and a timestamp in order to have one index per day.