### PR TITLE
fixing the error following ES 6.2 migration

### DIFF
--- a/src/main/groovy/com/ullink/testtools/elastic/TestExportTask.groovy
+++ b/src/main/groovy/com/ullink/testtools/elastic/TestExportTask.groovy
@@ -7,6 +7,7 @@ import groovy.util.logging.Slf4j
 import org.elasticsearch.action.bulk.BulkProcessor
 import org.elasticsearch.action.index.IndexRequest
 import org.elasticsearch.client.transport.TransportClient
+import org.elasticsearch.common.xcontent.XContentType
 import org.gradle.api.tasks.Exec
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
@@ -133,7 +134,7 @@ class TestExportTask extends Exec {
                 }
                 String id = sha1Hashed(it.getClassname() + it.getName() + it.timestamp)
                 IndexRequest indexObj = new IndexRequest(index, typeFinal, id)
-                processor.add(indexObj.source(output))
+                processor.add(indexObj.source(XContentType.JSON, output))
             }
         }
 


### PR DESCRIPTION
"The number of object passed must be even but was [1]" was thrown
since the migration to ES 6 when seting the source of the index.

With the new version of ES it is required to set the XContentType
to index a string value.