### PR TITLE
FIX calling the right source overloaded method

### DIFF
--- a/src/main/groovy/com/ullink/testtools/elastic/TestExportTask.groovy
+++ b/src/main/groovy/com/ullink/testtools/elastic/TestExportTask.groovy
@@ -134,7 +134,7 @@ class TestExportTask extends Exec {
                 }
                 String id = sha1Hashed(it.getClassname() + it.getName() + it.timestamp)
                 IndexRequest indexObj = new IndexRequest(index, typeFinal, id)
-                processor.add(indexObj.source(XContentType.JSON, output))
+                processor.add(indexObj.source(output, XContentType.JSON))
             }
         }
 


### PR DESCRIPTION
the arguments were inverted, and this was calling the wrong overloaded method.