### PR TITLE
Include failure text in test result

### DIFF
--- a/src/main/groovy/com/ullink/testtools/elastic/TestExportTask.groovy
+++ b/src/main/groovy/com/ullink/testtools/elastic/TestExportTask.groovy
@@ -171,6 +171,7 @@ class TestExportTask extends Exec {
                 result.with {
                     failureMessage = node.@message
                     failureType = node.@type
+                    failureText = node.text()
                     resultType = TestResult.ResultType.FAILURE
                 }
             }

--- a/src/main/groovy/com/ullink/testtools/elastic/models/Result.groovy
+++ b/src/main/groovy/com/ullink/testtools/elastic/models/Result.groovy
@@ -8,6 +8,7 @@ class Result {
     float executionTime
     String failureMessage
     String failureType
+    String failureText
     TestResult.ResultType resultType
     String timestamp
     Map<String, ?> properties


### PR DESCRIPTION
In case of a failure, text can be very useful for understanding what failed (e.g. a stack trace)