### PR TITLE
Export only existing directories

### DIFF
--- a/src/main/groovy/com/ullink/testtools/elastic/TestExportTask.groovy
+++ b/src/main/groovy/com/ullink/testtools/elastic/TestExportTask.groovy
@@ -88,7 +88,9 @@ class TestExportTask extends Exec {
             targetDirectory = []
             project.tasks.withType(Test.class).forEach {
                 def xmlReport = it.reports.getJunitXml()
-                targetDirectory << xmlReport.getDestination()
+                if (xmlReport.destination.exists()) {
+                    targetDirectory << xmlReport.getDestination()
+                }
             }
         }
         if (targetDirectory instanceof GString) {


### PR DESCRIPTION
When the output directory does not exist (e.g. no test was executed)
the task throws an IOException.