### PR TITLE
Remove Gradle version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,1 @@
 group=com.ullink.gradle
-version=0.6-SNAPSHOT


### PR DESCRIPTION
As the plugin is released with JitPack the version is redundant.