### PR TITLE
Use ES autogenerated id

### DIFF
--- a/src/main/groovy/com/ullink/testtools/elastic/TestExportTask.groovy
+++ b/src/main/groovy/com/ullink/testtools/elastic/TestExportTask.groovy
@@ -15,7 +15,6 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.TestResult
 
-import java.security.MessageDigest
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -134,19 +133,12 @@ class TestExportTask extends Exec {
                         throw new IllegalArgumentException("'type' attribute of type ${type.getClass()} is not supported")
                 }
 
-                String id = sha1Hashed(it.getClassname() + it.getName() + it.timestamp)
-                IndexRequest indexObj = new IndexRequest(index, typeFinal, id)
+                IndexRequest indexObj = new IndexRequest(index, typeFinal)
                 processor.add(indexObj.source(output, XContentType.JSON))
             }
         }
 
         processor.close()
-    }
-
-    static def sha1Hashed(String value) {
-        def messageDigest = MessageDigest.getInstance("SHA-1")
-        String hexString = messageDigest.digest(value.getBytes()).collect { String.format('%02x', it) }.join()
-        return hexString
     }
 
     List<Result> parseTestFiles(List<File> files) {

--- a/src/test/groovy/com/ullink/testtools/elastic/models/ResultObjectTest.groovy
+++ b/src/test/groovy/com/ullink/testtools/elastic/models/ResultObjectTest.groovy
@@ -1,6 +1,5 @@
 package com.ullink.testtools.elastic.models
 
-import com.ullink.testtools.elastic.TestExportTask
 import spock.lang.Specification
 
 class ResultObjectTest extends Specification {
@@ -8,11 +7,6 @@ class ResultObjectTest extends Specification {
     def 'should create Test Object'() {
         expect:
         new Result() instanceof Result
-    }
-
-    def 'sha1 hash'() {
-        expect:
-        TestExportTask.sha1Hashed('ABCDEF') == '970093678b182127f60bb51b8af2c94d539eca3a'
     }
 
 }


### PR DESCRIPTION
ES is smart enough to generate unique ids. There is no need to do this
here.