### PR TITLE
Use field initialization for default values

### DIFF
--- a/src/main/groovy/com/ullink/testtools/elastic/ElasticSearchProcessor.groovy
+++ b/src/main/groovy/com/ullink/testtools/elastic/ElasticSearchProcessor.groovy
@@ -11,14 +11,6 @@ import org.elasticsearch.transport.client.PreBuiltTransportClient
 
 class ElasticSearchProcessor {
 
-    InputStream DEFAULT_PROPERTIES_FILE
-    Properties parameters
-
-    ElasticSearchProcessor() {
-        DEFAULT_PROPERTIES_FILE = ElasticSearchProcessor.class.getResourceAsStream("/elastic-search.properties")
-        this.parameters = new PropertiesLoader(DEFAULT_PROPERTIES_FILE).getParameters()
-    }
-
     def buildTransportClient(Properties parameters) {
         String clusterName = parameters.getProperty("clusterName", "elasticsearch")
         Settings settings = new Settings.Builder()

--- a/src/main/groovy/com/ullink/testtools/elastic/TestExportTask.groovy
+++ b/src/main/groovy/com/ullink/testtools/elastic/TestExportTask.groovy
@@ -25,15 +25,15 @@ class TestExportTask extends Exec {
 
     @Input
     @Optional
-    String port
+    String port = "9300"
 
     @Input
     @Optional
-    String clusterName
+    String clusterName = "elasticsearch"
 
     @Input
     @Optional
-    String host
+    String host = "127.0.0.1"
 
     @Input
     @Optional
@@ -68,25 +68,13 @@ class TestExportTask extends Exec {
     @Internal
     TransportClient client
 
-    static def overrideDefaultProperties(TestExportTask task, Properties properties) {
-        if (task.host != null) {
-            log.info "setting host ${task.host}" +
-            properties.setProperty('host', task.host)
-        }
-        if (task.clusterName != null) {
-            properties.setProperty('clusterName', task.clusterName)
-        }
-        if (task.port != null) {
-            properties.setProperty('port', task.port)
-        }
-
-        return properties
-    }
-
     @Override
     void exec() {
         ElasticSearchProcessor elasticSearchProcessor = new ElasticSearchProcessor()
-        Properties parameters = overrideDefaultProperties(this, elasticSearchProcessor.getParameters())
+        Properties parameters = new Properties()
+        parameters.setProperty('host', host)
+        parameters.setProperty('port', port)
+        parameters.setProperty('clusterName', clusterName)
 
         def bulkProcessorListener = elasticSearchProcessor.buildBulkProcessorListener()
         client = elasticSearchProcessor.buildTransportClient(parameters)

--- a/src/main/resources/elastic-search.properties
+++ b/src/main/resources/elastic-search.properties
@@ -1,3 +1,0 @@
-clusterName=elasticsearch
-host=127.0.0.1
-port=9300


### PR DESCRIPTION
This should fix the fields not being overridden properly when task is created by another plugin.